### PR TITLE
Hotfix version 0.2.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ml_tooling
-version = 0.2.1
+version = 0.2.2
 description = A library for machine learning utilities
 url = https://github.com/andersbogsnes/ml_tooling
 long_description = file:README.md


### PR DESCRIPTION
Broke setup.cfg by not specifying a ~= on python_requires