### PR TITLE
Fix: ml_tooling-129 Cannot save a model that has only been trained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ v0.5.1
 - .train_model will now reset the result attribute to None, in order to 
 prevent users from mistakenly assuming the result is from the training 
 - Fixed bug in lift_score when using dataframes
+- Fixed bug where users could not save models if no result had been created, as would 
+happen if the user only called .train_model before saving.
 
 
 v0.5.0

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -147,9 +147,12 @@ class BaseClassModel(metaclass=abc.ABCMeta):
         model_file = current_dir.joinpath(save_name)
         joblib.dump(self.model, model_file)
 
-        metric_scores = {self.result.metric: float(self.result.score)}
-
         if self.config.LOG:
+            if self.result is None:
+                raise MLToolingError("You haven't scored the model - no results available to log")
+
+            metric_scores = {self.result.metric: float(self.result.score)}
+
             log_model(metric_scores=metric_scores,
                       model_name=self.model_name,
                       model_params=self.result.model_params,

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -128,6 +128,19 @@ class TestBaseClass:
         expected_name = 'IrisModel_LogisticRegression_1234.pkl'
         assert save_dir.join(expected_name).check()
 
+    def test_save_model_saves_pipeline_correctly(self, base, pipeline_logistic, monkeypatch,
+                                                 tmpdir):
+        def mockreturn():
+            return '1234'
+
+        monkeypatch.setattr('ml_tooling.baseclass.get_git_hash', mockreturn)
+        save_dir = tmpdir.mkdir('model')
+        model = base(pipeline_logistic)
+        model.train_model()
+        model.save_model(save_dir)
+        expected_name = 'IrisModel_LogisticRegression_1234.pkl'
+        assert save_dir.join(expected_name).check()
+
     def test_save_model_saves_logging_dir_correctly(self, classifier, tmpdir, monkeypatch):
         def mockreturn():
             return '1234'
@@ -222,3 +235,13 @@ class TestBaseClass:
                 result = yaml.safe_load(f)
                 model_name = result['model_name']
                 assert model_name in {'RandomForestClassifier', 'DummyClassifier'}
+
+    def test_train_model_errors_correct_when_not_scored(self,
+                                                        base,
+                                                        pipeline_logistic,
+                                                        tmpdir):
+        model = base(pipeline_logistic)
+        with pytest.raises(MLToolingError, match="You haven't scored the model"):
+            with model.log(tmpdir):
+                model.train_model()
+                model.save_model(tmpdir)


### PR DESCRIPTION
Fixed bug by adding a check for self.result being none

- [x] closes issue #129 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md
