### PR TITLE
Fix gridsearch multi mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bugfixes
 - Data for a class is changed from instance varaible to class variable
+- Grid search only copies data to workers once and reuse them across grid and folds.
 
 # v0.6.0
 

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -10,9 +10,7 @@ from sklearn import clone
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
 from sklearn.externals import joblib
-from sklearn.model_selection import cross_val_score
-from sklearn.model_selection import fit_grid_point
-from sklearn.model_selection._split import check_cv
+from sklearn.model_selection import cross_val_score, fit_grid_point, check_cv
 from sklearn.utils import indexable
 
 from .logging import create_logger, log_model
@@ -403,9 +401,12 @@ class BaseClassModel(metaclass=abc.ABCMeta):
                                            parameters=parameters) for parameters, (train, test)
             in product(list(param_grid), cv.split(train_x, train_y, None)))
 
-        fold_scores = 
+        scores = [np.array([score[0] for score in out if score[1] == param]) for param in
+                  list(param_grid)]
 
-        results = out
+        results = [CVResult(baseline_model., metric, scores[i], cv.n_splits) for i, param in
+                   enumerate(list(param_grid))]
+        
         logger.info("Done!")
 
         self.result = ResultGroup(results)

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -11,7 +11,6 @@ from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
 from sklearn.externals import joblib
 from sklearn.model_selection import cross_val_score, fit_grid_point, check_cv
-from sklearn.utils import indexable
 
 from .logging import create_logger, log_model
 from .utils import _validate_model
@@ -385,7 +384,7 @@ class BaseClassModel(metaclass=abc.ABCMeta):
         """
 
         baseline_model = clone(self.model)
-        train_x, train_y = indexable(self.data.train_x, self.data.train_y)
+        train_x, train_y = self.data.train_x, self.data.train_y
         metric = self.default_metric if metric is None else metric
         n_jobs = self.config.N_JOBS if n_jobs is None else n_jobs
         cv = self.config.CROSS_VALIDATION if cv is None else cv

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -394,20 +394,16 @@ class BaseClassModel(metaclass=abc.ABCMeta):
 
         parallel = joblib.Parallel(n_jobs=self.config.N_JOBS, verbose=self.config.VERBOSITY)
 
-        #        out = parallel(parallel_scoring(clone(baseline_model).set_params(**param),
-        #                                        metric=metric,
-        #                                        cv=cv) for param in param_grid)
-
         out = parallel(
             joblib.delayed(fit_grid_point)(X=train_x, y=train_y,
                                            estimator=clone(baseline_model),
                                            train=train, test=test,
                                            scorer=get_scoring_func(metric),
                                            verbose=self.config.VERBOSITY,
-                                           parameters=parameters)
-            for parameters, (train, test)
-            in product(list(param_grid),
-                       cv.split(train_x, train_y, None)))
+                                           parameters=parameters) for parameters, (train, test)
+            in product(list(param_grid), cv.split(train_x, train_y, None)))
+
+        fold_scores = 
 
         results = out
         logger.info("Done!")

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -384,11 +384,12 @@ class BaseClassModel(metaclass=abc.ABCMeta):
             ResultGroup object containing each individual score
         """
 
-        metric = self.default_metric if metric is None else metric
-        cv = check_cv(self.config.CROSS_VALIDATION) if cv is None else check_cv(cv)
-        n_jobs = self.config.N_JOBS if n_jobs is None else n_jobs
-        train_x, train_y = indexable(self.data.train_x, self.data.train_y)
         baseline_model = clone(self.model)
+        train_x, train_y = indexable(self.data.train_x, self.data.train_y)
+        metric = self.default_metric if metric is None else metric
+        n_jobs = self.config.N_JOBS if n_jobs is None else n_jobs
+        cv = self.config.CROSS_VALIDATION if cv is None else cv
+        cv = check_cv(cv, train_y, baseline_model._estimator_type == 'classifier')  # Stratify?
         self.result = None  # Fixes pickling recursion error in joblib
 
         logger.debug(f"Cross-validating with {cv}-fold cv using {metric}")

--- a/src/ml_tooling/utils.py
+++ b/src/ml_tooling/utils.py
@@ -8,6 +8,7 @@ from sklearn.base import BaseEstimator
 from sklearn.metrics import get_scorer
 from sklearn.model_selection import train_test_split, ParameterGrid
 from sklearn.pipeline import Pipeline
+from sklearn.utils import indexable
 
 DataType = Union[pd.DataFrame, np.ndarray]
 
@@ -18,8 +19,7 @@ class Data:
     """
 
     def __init__(self, x: DataType, y: DataType):
-        self.x = x
-        self.y = y
+        self.x, self.y = indexable(x, y)
         self.train_y = None
         self.train_x = None
         self.test_y = None


### PR DESCRIPTION
Only loads data into worker threads once. Only spawn one set of workers and use them across grid and folds. 

- [x] closes issue #157 and #156 
- [ ] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [ ] Updated README.md
