### PR TITLE
BUG: Added joblib as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v0.7.1
+- Joblib is now a dependency, instead of being vendored with scikit-learn
 # v0.7.0
 - Breaking change - BaseClassModel renamed to ModelData.
 - Breaking change - model renamed to estimator

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,17 +4,17 @@ version = 0.7
 description = A library for machine learning utilities
 url = https://github.com/andersbogsnes/ml_tooling
 long_description = file:README.md
-long_description_content_type=text/markdown
+long_description_content_type = text/markdown
 author = Anders Bogsnes
 author_email = abanbn@almbrand.dk
 license = MIT
 license_file = LICENSE
 classifiers =
-        Programming Language :: Python :: 3.6
-        Programming Language :: Python :: 3.7
-        Development Status :: 3 - Alpha
-        License :: OSI Approved :: MIT License
-        Operating System :: OS Independent
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Development Status :: 3 - Alpha
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
 keywords = ml, framework, tooling
 
 [options]
@@ -74,14 +74,11 @@ exclude_lines = def __repr__
 source = ml_tooling
 
 [tool:pytest]
-addopts = -p no:warnings -v  --cov ml_tooling --cov-report html --cov-report term
+addopts = -ra
 
 [tox:tox]
-envlist = py36
+envlist = py
 
 [testenv]
 deps = pytest==5.0.0
        pytest-cov==2.7.1
-
-commands = pytest --cov-config setup.cfg
-basepython= py36: python

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,13 @@ zip_safe = False
 python_requires = ~=3.6
 packages = find:
 install_requires =
-    pandas==0.24.2
+    pandas==0.25.0
     scikit-learn[alldeps]==0.21.2
-    numpy==1.16.4
     matplotlib==3.1.1
     gitpython==2.1.11
     pyyaml==5.1.1
+    joblib==0.13.2
+
 
 package_dir =
     = src
@@ -39,9 +40,11 @@ where = src
 * = *.mplstyle
 
 [options.extras_require]
-dev = pytest==5.0.0
-      pytest-cov==2.7.1
-
+test =
+    pytest==5.0.0
+    coverage==4.5.3
+docs =
+    sphinx
 
 
 [flake8]


### PR DESCRIPTION
Joblib is now an explicit dependency instead of being vendored in with scikit-learn

- [x] closes issue #229 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md

