### PR TITLE
Removed *args and **kwargs from Dataset.load_training_data

### DIFF
--- a/src/ml_tooling/data/base_data.py
+++ b/src/ml_tooling/data/base_data.py
@@ -90,7 +90,7 @@ class Dataset(metaclass=abc.ABCMeta):
         return True
 
     @abc.abstractmethod
-    def load_training_data(self, *args, **kwargs) -> Tuple[pd.DataFrame, np.array]:
+    def load_training_data(self) -> Tuple[pd.DataFrame, np.array]:
         """Abstract method to be implemented by user.
         Defines data to be used at training time where X is a dataframe and y is a numpy array
 


### PR DESCRIPTION
Prefer setting attributes in the `__init__` method and referring
to those in the method.

Very minor change