### PR TITLE
Fix bug with parallel feature importance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.9.2
 - Bug fix for logging when feature unions (DFFeatureUnion) had tuples
+- Bug fix for calculating feature importance when passing large amounts of data
 
 # v0.9.1
 - Hot fix python version to 3.7

--- a/src/ml_tooling/metrics/permutation_importance.py
+++ b/src/ml_tooling/metrics/permutation_importance.py
@@ -110,6 +110,8 @@ def permutation_importance(
     baseline_score = scorer(estimator, X, y)
     scores = np.zeros((X.shape[1], n_repeats))
 
+    # We set max_nbytes to None, to avoid joblib creating a readonly memmap
+    # Current implementation modifies the copied dataframe, so it fails when the mmap is readonly
     scores = Parallel(n_jobs=n_jobs, max_nbytes=None)(
         delayed(_calculate_permutation_scores)(
             estimator, X, y, col_idx, random_state, n_repeats, scorer

--- a/src/ml_tooling/metrics/permutation_importance.py
+++ b/src/ml_tooling/metrics/permutation_importance.py
@@ -26,8 +26,8 @@ def _safe_column_indexing(X, col_idx):
     """Return column from X using `col_idx`"""
     if hasattr(X, "iloc"):
         return X.iloc[:, col_idx].values
-    else:
-        return X[:, col_idx]
+
+    return X[:, col_idx]
 
 
 def _calculate_permutation_scores(

--- a/tests/fixtures/estimators.py
+++ b/tests/fixtures/estimators.py
@@ -12,29 +12,29 @@ from ml_tooling.transformers import DFStandardScaler, DFFeatureUnion, Select
 
 
 @pytest.fixture()
-def regression(base: type, test_dataset: Dataset) -> Model:
-    model: Model = base(LinearRegression())
+def regression(test_dataset: Dataset) -> Model:
+    model: Model = Model(LinearRegression())
     model.score_estimator(test_dataset)
     return model
 
 
 @pytest.fixture()
-def regression_cv(base: type, test_dataset: Dataset) -> Model:
-    model: Model = base(LinearRegression())
+def regression_cv(test_dataset: Dataset) -> Model:
+    model: Model = Model(LinearRegression())
     model.score_estimator(test_dataset, cv=2)
     return model
 
 
 @pytest.fixture()
-def classifier(base: type, test_dataset: Dataset) -> Model:
-    model: Model = base(LogisticRegression(solver="liblinear"))
+def classifier(test_dataset: Dataset) -> Model:
+    model: Model = Model(LogisticRegression(solver="liblinear"))
     model.score_estimator(test_dataset)
     return model
 
 
 @pytest.fixture()
-def classifier_cv(base: type, test_dataset: Dataset) -> Model:
-    model: Model = base(LogisticRegression(solver="liblinear"))
+def classifier_cv(test_dataset: Dataset) -> Model:
+    model: Model = Model(LogisticRegression(solver="liblinear"))
     model.score_estimator(test_dataset, cv=2)
     return model
 


### PR DESCRIPTION
When joblib.Parallel gets a large dataset, it does a read-only memmap
to avoid copying data. The feature importance implementation modifies
the passed object, creating an error. We turn off memmapping in the parallel process to avoid this problem

- [x] closes issue #338 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
