### PR TITLE
Fix storage save methods to only receive filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.9.2
 - Bug fix for logging when feature unions (DFFeatureUnion) had tuples
+- Bug fix when using default metric in `test_estimators`
 
 # v0.9.1
 - Hot fix python version to 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Bug fix when using default metric in `test_estimators`
 - Bug fix when gridsearching, only applying last change
 - Add nicer error message when passing incorrect dtypes to FillNA
+- Storage .save method now only takes filename as parameter
+- Handles storage loading of paths outputted from the Storage .get_list method
+
 
 # v0.9.1
 - Hot fix python version to 3.7

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -312,7 +312,7 @@ class Model:
         List of Result objects
         """
 
-        results = train_estimators(estimators, data, metrics, cv)
+        results = _train_estimators(estimators, data, metrics, cv)
 
         if log_dir:
             results.log(pathlib.Path(log_dir))
@@ -466,7 +466,7 @@ class Model:
             estimator=self.estimator, params=param_grid
         )
 
-        self.result = train_estimators(
+        self.result = _train_estimators(
             list(estimators), data=data, metrics=metrics, cv=cv
         )
 
@@ -529,14 +529,33 @@ class Model:
         return f"<Model: {self.estimator_name}>"
 
 
-def train_estimators(
+def _train_estimators(
     estimators: Sequence[Estimator],
     data: Dataset,
     metrics: Union[str, List[str]],
     cv: Any,
 ) -> ResultGroup:
-    if isinstance(metrics, str):
-        metrics = [metrics]
+    """
+    Sequentially train a series of models and create a ResultGroup of the results
+
+    Parameters
+    ----------
+    estimators: Sequence[Estimator]
+        A sequence of estimators to compare
+    data: DataSet
+        Dataset object containing the training data
+    metrics: Union[str, List[str]]
+        Which metric to use to score the estimators
+    cv: Any
+        If an int is passed, perform that many CV splits. Alternatively, pass a sklearn CV object
+        to use that for CV.
+        If False, do not perform cross-validation
+
+    Returns
+    -------
+    ResultGroup
+        The results of the scoring
+    """
 
     results = []
     for i, estimator in enumerate(estimators, start=1):

--- a/src/ml_tooling/storage/artifactory.py
+++ b/src/ml_tooling/storage/artifactory.py
@@ -70,7 +70,7 @@ class ArtifactoryStorage(Storage):
             list of paths to files sorted by filename
         """
 
-        return sorted(self.artifactory_path.glob("*/*.pkl"))
+        return sorted(self.artifactory_path.glob("*.pkl"))
 
     def load(self, file_path: Pathlike) -> Estimator:
         """
@@ -95,8 +95,11 @@ class ArtifactoryStorage(Storage):
         Object
             estimator unpickled object
         """
+        if ArtifactoryPath(file_path).is_file():
+            artifactory_path = file_path
+        else:
+            artifactory_path = self.artifactory_path / file_path
 
-        artifactory_path = self.artifactory_path / file_path
         with artifactory_path.open() as f:
             by = BytesIO()
             by.write(f.read())

--- a/src/ml_tooling/storage/file.py
+++ b/src/ml_tooling/storage/file.py
@@ -45,8 +45,8 @@ class FileStorage(Storage):
         Parameters
         ----------
 
-        file_path: str
-            filename of estimator pickle file
+        file_path: Pathlike
+            Path where to load the estimator file relative to FileStorage
 
         Example
         -------
@@ -65,7 +65,7 @@ class FileStorage(Storage):
         estimator_path = self.dir_path / file_path
         return joblib.load(estimator_path)
 
-    def save(self, estimator: Estimator, filepath: str, prod: bool = False) -> Path:
+    def save(self, estimator: Estimator, filename: str, prod: bool = False) -> Path:
         """
         Save a joblib pickled estimator.
 
@@ -74,13 +74,13 @@ class FileStorage(Storage):
         estimator: obj
             The estimator object
 
-        filepath: str
-            Path where to save file - relative to FileStorage
+        filename: str
+            filename of estimator pickle file
 
         prod: bool
             Whether or not to save in "production mode" -
-            Production mode saves to /src/<projectname>/ regardless of what FileStorage
-            was instantiated with
+            Production mode saves to /src/<projectname>/ regardless
+            of what FileStorage was instantiated with
 
         Example
         -------
@@ -98,9 +98,9 @@ class FileStorage(Storage):
         """
 
         if prod:
-            file_path = find_src_dir() / filepath
+            file_path = find_src_dir() / filename
         else:
-            file_path = make_dir(self.dir_path) / filepath
+            file_path = make_dir(self.dir_path) / filename
 
         joblib.dump(estimator, file_path)
         return file_path

--- a/src/ml_tooling/storage/file.py
+++ b/src/ml_tooling/storage/file.py
@@ -62,7 +62,10 @@ class FileStorage(Storage):
         Object
             The object loaded from disk
         """
-        estimator_path = self.dir_path / file_path
+        if Path(file_path).is_file():
+            estimator_path = file_path
+        else:
+            estimator_path = self.dir_path / file_path
         return joblib.load(estimator_path)
 
     def save(self, estimator: Estimator, filename: str, prod: bool = False) -> Path:

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -29,7 +29,9 @@ def test_can_load_from_artifactory(open_estimator_pickle):
 
 
 @require_artifactory
-def test_can_save_to_artifactory(open_estimator_pickle, tmp_path: pathlib.Path):
+def test_can_save_to_artifactory(
+    open_estimator_pickle, tmp_path: pathlib.Path, regression
+):
     file_path = tmp_path.joinpath("temp.pkl")
 
     def mock_deploy_file(*args, **kwargs):
@@ -37,10 +39,11 @@ def test_can_save_to_artifactory(open_estimator_pickle, tmp_path: pathlib.Path):
 
     mock = MagicMock()
     mock.__truediv__.deploy_file.return_value = mock_deploy_file()
+    mock.is_file.return_value = False
 
     storage = ArtifactoryStorage("http://www.testy.com", "/test")
     storage.artifactory_path = mock
-    storage.save("test", "test")
+    storage.save(regression.estimator, "test")
     f = joblib.load(file_path)
     assert isinstance(f, (BaseEstimator, Pipeline))
 

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -14,112 +14,115 @@ require_artifactory = pytest.mark.skipif(
 )
 
 
-@require_artifactory
-@patch("ml_tooling.storage.artifactory.ArtifactoryPath")
-def test_can_load_from_artifactory(artifactorypath_mock, open_estimator_pickle):
-    artifactorypath_mock.return_value.is_file.return_value = False
-
-    mock_open = MagicMock()
-    mock_open.open = open_estimator_pickle
-
-    mock_path = MagicMock()
-    mock_path.__truediv__.return_value = mock_open
-
-    storage = ArtifactoryStorage("http://www.testy.com/artifactory", "test")
-    storage.artifactory_path = mock_path
-    f = storage.load("test")
-
-    assert isinstance(f, (BaseEstimator, Pipeline))
-
-
-@require_artifactory
-def test_can_save_to_artifactory(
-    open_estimator_pickle, tmp_path: pathlib.Path, regression
-):
-    file_path = tmp_path.joinpath("temp.pkl")
-
-    def mock_deploy_file(*args, **kwargs):
-        return file_path.write_bytes(open_estimator_pickle().read())
-
-    mock = MagicMock()
-    mock.__truediv__.return_value.deploy_file = mock_deploy_file
-    mock.is_file.return_value = False
-
-    storage = ArtifactoryStorage("http://www.testy.com", "/test")
-    storage.artifactory_path = mock
-    storage.save(regression.estimator, "test")
-    f = joblib.load(file_path)
-    assert isinstance(f, (BaseEstimator, Pipeline))
-
-
-@require_artifactory
-@patch("ml_tooling.storage.artifactory.ArtifactoryPath")
-def test_can_get_list_of_paths(
-    artifactorypath_mock, estimator_pickle_path_factory, open_estimator_pickle
-):
-    artifactorypath_mock.return_value.is_file.return_value = False
-
-    paths = [
-        estimator_pickle_path_factory(
-            "LogisticRegression_2019-10-15_10:42:10.709197.pkl"
-        ),
-        estimator_pickle_path_factory(
-            "LogisticRegression_2019-10-15_10:32:41.780990.pkl"
-        ),
-        estimator_pickle_path_factory(
-            "LogisticRegression_2019-10-15_10:34:34.226695.pkl"
-        ),
-        estimator_pickle_path_factory(
-            "LogisticRegression_2019-10-15_10:51:50.760746.pkl"
-        ),
-        estimator_pickle_path_factory(
-            "LogisticRegression_2019-10-15_10:34:21.849358.pkl"
-        ),
-    ]
-
-    mock_open = MagicMock()
-    mock_open.open = open_estimator_pickle
-
-    mock = MagicMock()
-    mock.glob.return_value = paths
-    mock.__truediv__.return_value = mock_open
-
-    storage = ArtifactoryStorage("http://www.testy.com", "test", apikey="key")
-    storage.artifactory_path = mock
-    artifactory_paths = storage.get_list()
-
-    estimator = storage.load(artifactory_paths[0])
-
-    assert isinstance(estimator, (BaseEstimator, Pipeline))
-    assert artifactory_paths[0] == paths[1]
-    assert artifactory_paths[-1] == paths[3]
-
-
-@require_artifactory
-def test_artifactory_initialization_path():
-    from dohq_artifactory.auth import XJFrogArtApiAuth
-
-    storage = ArtifactoryStorage("http://www.testy.com", "test", apikey="key")
-
-    assert storage.artifactory_path.repo == "test"
-    assert storage.artifactory_path.drive == "http://www.testy.com/artifactory"
-    assert isinstance(storage.artifactory_path.auth, XJFrogArtApiAuth)
-    assert storage.artifactory_path.auth.apikey == "key"
-
-
-@require_artifactory
-def test_artifactory_initialization_with_artifactory_suffix_works_as_expected():
-    storage = ArtifactoryStorage("http://www.testy.com/artifactory", "test")
-    assert storage.artifactory_path.repo == "test"
-    assert storage.artifactory_path.drive == "http://www.testy.com/artifactory"
-    assert storage.artifactory_path.auth is None
-
-
-@patch("ml_tooling.storage.artifactory._has_artifactory")
-def test_using_artifactory_without_installed_fails(mock_const):
-    mock_const.__bool__.return_value = False
-    with pytest.raises(
-        MLToolingError,
-        match="Artifactory not installed - run pip install dohq-artifactory",
+class TestArtifactoryStorage:
+    @require_artifactory
+    @patch("ml_tooling.storage.artifactory.ArtifactoryPath")
+    def test_can_load_from_artifactory(
+        self, artifactorypath_mock, open_estimator_pickle
     ):
-        ArtifactoryStorage("test", "test")
+        artifactorypath_mock.return_value.is_file.return_value = False
+
+        mock_open = MagicMock()
+        mock_open.open = open_estimator_pickle
+
+        mock_path = MagicMock()
+        mock_path.__truediv__.return_value = mock_open
+
+        storage = ArtifactoryStorage("http://www.testy.com/artifactory", "test")
+        storage.artifactory_path = mock_path
+        f = storage.load("test")
+
+        assert isinstance(f, (BaseEstimator, Pipeline))
+
+    @require_artifactory
+    def test_can_save_to_artifactory(
+        self, open_estimator_pickle, tmp_path: pathlib.Path, regression
+    ):
+        file_path = tmp_path.joinpath("temp.pkl")
+
+        def mock_deploy_file(*args, **kwargs):
+            return file_path.write_bytes(open_estimator_pickle().read())
+
+        mock = MagicMock()
+        mock.__truediv__.return_value.deploy_file = mock_deploy_file
+        mock.is_file.return_value = False
+
+        storage = ArtifactoryStorage("http://www.testy.com", "/test")
+        storage.artifactory_path = mock
+        storage.save(regression.estimator, "test")
+        f = joblib.load(file_path)
+        assert isinstance(f, (BaseEstimator, Pipeline))
+
+    @require_artifactory
+    @patch("ml_tooling.storage.artifactory.ArtifactoryPath")
+    def test_can_get_list_of_paths_and_load_from_output(
+        self, artifactorypath_mock, estimator_pickle_path_factory, open_estimator_pickle
+    ):
+        artifactorypath_mock.return_value.is_file.return_value = False
+
+        paths = [
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:42:10.709197.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:32:41.780990.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:34:34.226695.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:51:50.760746.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:34:21.849358.pkl"
+            ),
+        ]
+
+        mock_open = MagicMock()
+        mock_open.open = open_estimator_pickle
+
+        mock = MagicMock()
+        mock.glob.return_value = paths
+        mock.__truediv__.return_value = mock_open
+
+        storage = ArtifactoryStorage("http://www.testy.com", "test", apikey="key")
+        storage.artifactory_path = mock
+        artifactory_paths = storage.get_list()
+
+        estimator = storage.load(artifactory_paths[0])
+        assert isinstance(estimator, (BaseEstimator, Pipeline))
+
+        artifactorypath_mock.return_value.is_file.return_value = True
+
+        estimator = storage.load(mock_open)
+        assert isinstance(estimator, (BaseEstimator, Pipeline))
+
+        assert artifactory_paths[0] == paths[1]
+        assert artifactory_paths[-1] == paths[3]
+
+    @require_artifactory
+    def test_artifactory_initialization_path(self):
+        from dohq_artifactory.auth import XJFrogArtApiAuth
+
+        storage = ArtifactoryStorage("http://www.testy.com", "test", apikey="key")
+
+        assert storage.artifactory_path.repo == "test"
+        assert storage.artifactory_path.drive == "http://www.testy.com/artifactory"
+        assert isinstance(storage.artifactory_path.auth, XJFrogArtApiAuth)
+        assert storage.artifactory_path.auth.apikey == "key"
+
+    @require_artifactory
+    def test_artifactory_initialization_with_artifactory_suffix_works_as_expected(self):
+        storage = ArtifactoryStorage("http://www.testy.com/artifactory", "test")
+        assert storage.artifactory_path.repo == "test"
+        assert storage.artifactory_path.drive == "http://www.testy.com/artifactory"
+        assert storage.artifactory_path.auth is None
+
+    @patch("ml_tooling.storage.artifactory._has_artifactory")
+    def test_using_artifactory_without_installed_fails(self, mock_const):
+        mock_const.__bool__.return_value = False
+        with pytest.raises(
+            MLToolingError,
+            match="Artifactory not installed - run pip install dohq-artifactory",
+        ):
+            ArtifactoryStorage("test", "test")

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -269,7 +269,7 @@ class TestBaseClass:
     def test_can_load_production_estimator(
         self, mock_path: MagicMock, open_estimator_pickle
     ):
-        mock_path.return_value.__enter__.return_value = open_estimator_pickle
+        mock_path.return_value.__enter__.return_value = open_estimator_pickle()
         model = Model.load_production_estimator("test")
         assert isinstance(model, Model)
         assert isinstance(model.estimator, BaseEstimator)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -58,6 +58,37 @@ class TestFileStorage:
         for filename in filenames_list:
             assert filename.exists()
 
+    def test_can_get_list_of_paths_and_load_from_output(
+        self, estimator_pickle_path_factory, tmp_path
+    ):
+        paths = [
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:42:10.709197.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:32:41.780990.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:34:34.226695.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:51:50.760746.pkl"
+            ),
+            estimator_pickle_path_factory(
+                "LogisticRegression_2019-10-15_10:34:21.849358.pkl"
+            ),
+        ]
+
+        storage = FileStorage(tmp_path)
+
+        estimators = storage.get_list()
+
+        first_estimator = storage.load(estimators[0])
+
+        assert isinstance(first_estimator, (BaseEstimator, Pipeline))
+        assert estimators[0] == paths[1]
+        assert estimators[-1] == paths[3]
+
     def test_raise_when_non_dir(self, classifier: Model, tmp_path: pathlib.Path):
         with pytest.raises(
             MLToolingError, match="dir_path is /not/a/dir.file which is not a directory"


### PR DESCRIPTION
Storage save method accepted Paths as argument, but was handled as a filename string. This changes the method to only receive a filename to save, then we can add Path functionality later if we need it.

- [x] closes issue #
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [ ] Updated README.md
