### PR TITLE
Fix fillna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.2
 - Bug fix for logging when feature unions (DFFeatureUnion) had tuples
 - Bug fix when using default metric in `test_estimators`
+- Add nicer error message when passing incorrect dtypes to FillNA
 
 # v0.9.1
 - Hot fix python version to 3.7

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -233,6 +233,29 @@ class TestFillNA(TransformerBase):
         result = model.score_estimator(test_dataset)
         assert isinstance(result, Result)
 
+    def test_fillna_raises_when_imputing_numerically_on_strings(self):
+        df = pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "status": ["OK", "Error", "OK", "Error"],
+                "sales": [2000, 3000, 4000, np.nan],
+            }
+        )
+        fill_na = FillNA(strategy="mean")
+        with pytest.raises(
+            TransformerError,
+            match="column/columns have invalid types for strategy = mean",
+        ):
+            fill_na.fit_transform(df)
+
+        df["new_col"] = ["One", "Two", "Three", "Four"]
+
+        with pytest.raises(
+            TransformerError,
+            match="column/columns have invalid types for strategy = mean",
+        ):
+            fill_na.fit_transform(df)
+
 
 class TestToCategorical(TransformerBase):
     def test_to_categorical_returns_correct_dataframe(self, categorical: pd.DataFrame):


### PR DESCRIPTION
FillNA would fail cryptically if passed a dataframe containing
a string if the strategy was a numeric-based strategy.

Added error-handling to give the user a nicer message and added
tests for it

- [x] closes issue #240 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
