### PR TITLE
Fix ml tooling no y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bug fix when using default metric in `test_estimators`
 - Bug fix when gridsearching, only applying last change
 - Add nicer error message when passing incorrect dtypes to FillNA
+- Handles case when Dataset does not have a `y` value
 
 # v0.9.1
 - Hot fix python version to 3.7

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -22,7 +22,7 @@ from ml_tooling.search.gridsearch import prepare_gridsearch_estimators
 from ml_tooling.utils import (
     MLToolingError,
     _validate_estimator,
-    DataSetError,
+    DatasetError,
     Estimator,
     is_pipeline,
     serialize_pipeline,
@@ -397,7 +397,7 @@ class Model:
         logger.info("Scoring estimator...")
 
         if not data.has_validation_set:
-            raise DataSetError("Must run create_train_test first!")
+            raise DatasetError("Must run create_train_test first!")
 
         self.estimator.fit(data.train_x, data.train_y)
 

--- a/src/ml_tooling/data/base_data.py
+++ b/src/ml_tooling/data/base_data.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import pandas as pd
 from sklearn.model_selection import train_test_split
-from ml_tooling.utils import DataType, DataSetError
+from ml_tooling.utils import DataType, DatasetError
 from sklearn.utils import indexable
 
 
@@ -46,6 +46,11 @@ class Dataset(metaclass=abc.ABCMeta):
         -------
         self
         """
+        if self.y is None:
+            raise DatasetError(
+                "The dataset does not define a y value"
+                " - cannot create a train-test split"
+            )
 
         self.train_x, self.test_x, self.train_y, self.test_y = train_test_split(
             self.x,
@@ -65,7 +70,7 @@ class Dataset(metaclass=abc.ABCMeta):
 
     @x.setter
     def x(self, data):
-        raise DataSetError("Trying to modify x - x is immutable")
+        raise DatasetError("Trying to modify x - x is immutable")
 
     @property
     def y(self):
@@ -75,7 +80,7 @@ class Dataset(metaclass=abc.ABCMeta):
 
     @y.setter
     def y(self, data):
-        raise DataSetError("Trying to modify y - y is immutable")
+        raise DatasetError("Trying to modify y - y is immutable")
 
     @property
     def has_validation_set(self):

--- a/src/ml_tooling/utils.py
+++ b/src/ml_tooling/utils.py
@@ -28,7 +28,7 @@ class TransformerError(MLToolingError):
     """Error which occurs during a transform"""
 
 
-class DataSetError(MLToolingError):
+class DatasetError(MLToolingError):
     """Error which occurs when using a DataSet"""
 
 

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -21,7 +21,7 @@ from ml_tooling.metrics import Metrics, Metric
 from ml_tooling.result import Result
 from ml_tooling.search.gridsearch import prepare_gridsearch_estimators
 from ml_tooling.transformers import DFStandardScaler, DFFeatureUnion
-from ml_tooling.utils import MLToolingError
+from ml_tooling.utils import MLToolingError, DatasetError
 
 
 class TestBaseClass:
@@ -459,6 +459,9 @@ class TestTrainEstimator:
         model.train_estimator(data)
 
         assert np.all(np.isclose(model.estimator.average, np.array([2.5, 5.5])))
+
+        with pytest.raises(DatasetError, match="The dataset does not define a y value"):
+            data.create_train_test()
 
 
 class TestScoreEstimator:

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 import datetime
 
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
@@ -37,26 +37,6 @@ class TestBaseClass:
 
         pipeline = Model(pipeline_linear)
         assert pipeline.is_pipeline is True
-
-    def test_can_score_estimator_with_default_metric(self, test_dataset: Dataset):
-        model = Model(LogisticRegression(solver="liblinear"))
-        result = model.score_estimator(test_dataset)
-
-        assert result.metrics.name == "accuracy"
-
-    def test_can_score_estimator_with_specified_metric(self, test_dataset: Dataset):
-        model = Model(LogisticRegression(solver="liblinear"))
-        result = model.score_estimator(test_dataset, metrics="roc_auc")
-
-        assert result.metrics.name == "roc_auc"
-
-    def test_can_score_estimator_with_multiple_metrics(self, test_dataset: Dataset):
-        model = Model(LogisticRegression(solver="liblinear"))
-        result = model.score_estimator(test_dataset, metrics=["accuracy", "roc_auc"])
-
-        assert len(result.metrics) == 2
-        assert "accuracy" in result.metrics
-        assert "roc_auc" in result.metrics
 
     def test_instantiate_model_with_non_estimator_pipeline_fails(self):
         example_pipe = Pipeline([("scale", DFStandardScaler)])
@@ -128,12 +108,6 @@ class TestBaseClass:
             start=expected_index, stop=expected_index + 1, step=1
         )
 
-    def test_score_estimator_fails_if_no_train_test_data_available(self, base_dataset):
-        model = Model(LinearRegression())
-
-        with pytest.raises(MLToolingError, match="Must run create_train_test first!"):
-            model.score_estimator(base_dataset())
-
     def test_default_metric_getter_works_as_expected_classifier(self):
         rf = Model(RandomForestClassifier(n_estimators=10))
         assert rf.config.CLASSIFIER_METRIC == "accuracy"
@@ -181,36 +155,6 @@ class TestBaseClass:
         assert "neg_mean_squared_error" == linreg.default_metric
         logreg.reset_config()
         linreg.reset_config()
-
-    def test_train_model_sets_result_to_none(
-        self, regression: Model, test_dataset: Dataset
-    ):
-        assert regression.result is not None
-        regression.train_estimator(test_dataset)
-        assert regression.result is None
-
-    def test_train_model_followed_by_score_model_returns_correctly(
-        self, pipeline_logistic: Pipeline, test_dataset: Dataset
-    ):
-        model = Model(pipeline_logistic)
-        model.train_estimator(test_dataset)
-        model.score_estimator(test_dataset)
-
-        assert isinstance(model.result, Result)
-
-    def test_model_selection_works_as_expected(self, test_dataset: Dataset):
-        models = [
-            LogisticRegression(solver="liblinear"),
-            RandomForestClassifier(n_estimators=10),
-        ]
-        best_model, results = Model.test_estimators(
-            test_dataset, models, metrics="accuracy"
-        )
-        assert models[1] is best_model.estimator
-        assert 2 == len(results)
-        assert results[0].metrics[0].score >= results[1].metrics[0].score
-        for result in results:
-            assert isinstance(result, Result)
 
     def test_regression_model_can_be_saved(
         self, classifier: Model, tmp_path: pathlib.Path, test_dataset: Dataset
@@ -321,16 +265,6 @@ class TestBaseClass:
                     "IrisData_RandomForestClassifier",
                     "IrisData_DummyClassifier",
                 }
-
-    def test_train_model_errors_correctly_when_not_scored(
-        self, pipeline_logistic: Pipeline, tmp_path: pathlib.Path, test_dataset: Dataset
-    ):
-
-        model = Model(pipeline_logistic)
-        with pytest.raises(MLToolingError, match="You haven't scored the estimator"):
-            with model.log(str(tmp_path)):
-                model.train_estimator(test_dataset)
-                model.save_estimator(FileStorage(tmp_path))
 
     def test_dump_serializes_correctly_without_pipeline(self, regression: Model):
         serialized_model = regression.to_dict()
@@ -475,7 +409,101 @@ class TestBaseClass:
         assert model2.estimator.get_params() == classifier.estimator.get_params()
 
 
+class TestTrainEstimator:
+    def test_train_model_sets_result_to_none(
+        self, regression: Model, test_dataset: Dataset
+    ):
+        assert regression.result is not None
+        regression.train_estimator(test_dataset)
+        assert regression.result is None
+
+    def test_train_model_followed_by_score_model_returns_correctly(
+        self, pipeline_logistic: Pipeline, test_dataset: Dataset
+    ):
+        model = Model(pipeline_logistic)
+        model.train_estimator(test_dataset)
+        model.score_estimator(test_dataset)
+
+        assert isinstance(model.result, Result)
+
+    def test_train_model_errors_correctly_when_not_scored(
+        self, pipeline_logistic: Pipeline, tmp_path: pathlib.Path, test_dataset: Dataset
+    ):
+        model = Model(pipeline_logistic)
+        with pytest.raises(MLToolingError, match="You haven't scored the estimator"):
+            with model.log(str(tmp_path)):
+                model.train_estimator(test_dataset)
+                model.save_estimator(FileStorage(tmp_path))
+
+    def test_can_score_estimator_with_no_y_value(self):
+        class DummyEstimator(BaseEstimator, RegressorMixin):
+            def __init__(self):
+                self.average = None
+
+            def fit(self, x, y=None):
+                self.average = np.mean(x, axis=1)
+                return self
+
+            def predict(self, x):
+                return self.average
+
+        class DummyData(Dataset):
+            def load_training_data(self):
+                return np.array([[1, 2, 3, 4], [4, 5, 6, 7]]), None
+
+            def load_prediction_data(self, *args, **kwargs):
+                return np.array([[1, 2, 3, 4], [4, 5, 6, 7]])
+
+        model = Model(DummyEstimator())
+        data = DummyData()
+        model.train_estimator(data)
+
+        assert np.all(np.isclose(model.estimator.average, np.array([2.5, 5.5])))
+
+
+class TestScoreEstimator:
+    def test_score_estimator_fails_if_no_train_test_data_available(self, base_dataset):
+        model = Model(LinearRegression())
+
+        with pytest.raises(MLToolingError, match="Must run create_train_test first!"):
+            model.score_estimator(base_dataset())
+
+    def test_can_score_estimator_with_specified_metric(self, test_dataset: Dataset):
+        model = Model(LogisticRegression(solver="liblinear"))
+        result = model.score_estimator(test_dataset, metrics="roc_auc")
+
+        assert result.metrics.name == "roc_auc"
+
+    def test_can_score_estimator_with_default_metric(self, test_dataset: Dataset):
+        model = Model(LogisticRegression(solver="liblinear"))
+        result = model.score_estimator(test_dataset)
+
+        assert result.metrics.name == "accuracy"
+
+    def test_can_score_estimator_with_multiple_metrics(self, test_dataset: Dataset):
+        model = Model(LogisticRegression(solver="liblinear"))
+        result = model.score_estimator(test_dataset, metrics=["accuracy", "roc_auc"])
+
+        assert len(result.metrics) == 2
+        assert "accuracy" in result.metrics
+        assert "roc_auc" in result.metrics
+
+
 class TestModelSelection:
+    def test_model_selection_works_as_expected(self, test_dataset: Dataset):
+        models = [
+            LogisticRegression(solver="liblinear"),
+            RandomForestClassifier(n_estimators=10),
+        ]
+        best_model, results = Model.test_estimators(
+            test_dataset, models, metrics="accuracy"
+        )
+        assert models[1] is best_model.estimator
+        assert 2 == len(results)
+        assert results[0].metrics[0].score >= results[1].metrics[0].score
+        for result in results:
+            assert isinstance(result, Result)
+
     def test_model_selection_works_with_default_metric(self, test_dataset: Dataset):
         models = [
             LogisticRegression(solver="liblinear"),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ml_tooling.data import SQLDataset, Dataset
-from ml_tooling.utils import DataSetError
+from ml_tooling.utils import DatasetError
 
 
 def test_repr_is_correct(test_dataset):
@@ -43,9 +43,9 @@ def test_sqldataset_can_be_instantiated_with_engine_string():
 
 
 def test_cant_modify_x_and_y(test_dataset):
-    with pytest.raises(DataSetError, match="Trying to modify x - x is immutable"):
+    with pytest.raises(DatasetError, match="Trying to modify x - x is immutable"):
         test_dataset.x = "testx"
-    with pytest.raises(DataSetError, match="Trying to modify y - y is immutable"):
+    with pytest.raises(DatasetError, match="Trying to modify y - y is immutable"):
         test_dataset.y = "testy"
 
 


### PR DESCRIPTION
`Dataset.create_train_test` now raises when `y` is set to  `None`

- [x] closes issue #263 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
