### PR TITLE
Use to_sql to _load_data, and fix load_prediction_data signature and caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.10.2
+- Fixed type inferences from data to sql in _load_data
+- Added idx arg to load_prediction_data abstract method in SQLDataset
+- Added caching of loaded data in SQLDataset
+
 # v0.10.1
 - Added `.copy_to` functionality to SQLDataset and FileDataset,
 allowing copying between datasets

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -39,7 +39,7 @@ sqlalchemy==1.3.13
 toml==0.10.0              # via pre-commit, tox
 tox==3.14.3
 urllib3==1.25.8           # via requests
-virtualenv==20.0.0        # via pre-commit, tox
+virtualenv==20.0.1        # via pre-commit, tox
 wcwidth==0.1.8            # via pytest
 zipp==2.2.0               # via importlib-metadata
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -103,6 +103,7 @@ def boston_sqldataset():
             sa.Column("PTRATIO", sa.Float),
             sa.Column("B", sa.Float),
             sa.Column("LSTAT", sa.Float),
+            sa.Column("MEDV", sa.Float),
         )
 
         def load_training_data(
@@ -112,9 +113,9 @@ def boston_sqldataset():
             df = pd.read_sql(sql, conn)
             return df.drop(columns="MEDV"), df.MEDV
 
-        def load_prediction_data(self, conn, idx) -> DataType:
+        def load_prediction_data(self, idx, conn) -> DataType:
             sql = "SELECT * FROM boston"
-            return pd.read_sql(sql, conn).loc[[idx]]
+            return pd.read_sql(sql, conn).loc[[idx]].drop(columns="MEDV")
 
     return BostonSQLData
 
@@ -133,14 +134,16 @@ def iris_sqldataset():
             sa.Column("petal width (cm)", sa.Float),
         )
 
-        def load_training_data(self) -> Tuple[pd.DataFrame, DataType]:
+        def load_training_data(
+            self, conn, *args, **kwargs
+        ) -> Tuple[pd.DataFrame, DataType]:
             sql = "SELECT * FROM iris"
             df = pd.read_sql(sql, self.engine)
             return df.drop(columns="target"), df.target
 
-        def load_prediction_data(self, conn, idx) -> pd.DataFrame:
+        def load_prediction_data(self, idx, conn) -> pd.DataFrame:
             sql = "SELECT * FROM iris"
-            return pd.read_sql(sql, self.engine).loc[[idx]]
+            return pd.read_sql(sql, self.engine).loc[[idx]].drop(columns="target")
 
     return IrisSQLData
 

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -58,6 +58,30 @@ class TestBaseClass:
             model = Model(LinearRegression())
             model.make_prediction(train_iris_dataset, 5)
 
+    def test_make_prediction_with_regression_sqldataset_works_as_expected(
+        self, boston_sqldataset, loaded_boston_db
+    ):
+        dataset = boston_sqldataset(loaded_boston_db, schema=None)
+        dataset.create_train_test()
+        model = Model(LinearRegression())
+        model.train_estimator(dataset)
+
+        result = model.make_prediction(dataset, 0)
+
+        assert result.shape == (1, 1)
+
+    def test_make_prediction_with_classification_sqldataset_works_as_expected(
+        self, iris_sqldataset, loaded_iris_db
+    ):
+        dataset = iris_sqldataset(loaded_iris_db, schema=None)
+        dataset.create_train_test()
+        model = Model(LogisticRegression(solver="lbfgs"))
+        model.train_estimator(dataset)
+
+        result = model.make_prediction(dataset, 0, proba=True)
+
+        assert result.shape == (1, 2)
+
     def test_make_prediction_errors_if_asked_for_proba_without_predict_proba_method(
         self, train_iris_dataset
     ):


### PR DESCRIPTION
data.to_dict in _load_data execution has some problems with inference of data types, and fixes load_prediction_data argument signature and caching of prediction data.

- [x] Tests added
- [x] Passes flake8
- [ ] Updated CHANGELOG
- [ ] Updated README.md
