### PR TITLE
Add default filestorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.10.3
+- Added default local filestorage when using `save_estimator`
+
 # v0.10.2
 - Fixed type inferences from data to sql in _load_data
 - Added idx arg to load_prediction_data abstract method in SQLDataset

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -1,24 +1,20 @@
-from importlib.resources import path as import_path
-import pathlib
 import datetime
+import pathlib
 from contextlib import contextmanager
+from importlib.resources import path as import_path
 from typing import Tuple, Optional, Sequence, Union, List, Iterable, Any
 
 import joblib
 import pandas as pd
-from sklearn.base import is_classifier, is_regressor
-from sklearn.exceptions import NotFittedError
-from sklearn.model_selection import check_cv
-
 from ml_tooling.config import DefaultConfig, ConfigGetter
 from ml_tooling.data.base_data import Dataset
-from ml_tooling.result import ResultType
-from ml_tooling.storage.base import Storage
 from ml_tooling.logging.logger import create_logger
+from ml_tooling.metrics.metric import Metrics
+from ml_tooling.result import ResultType
 from ml_tooling.result.result import Result
 from ml_tooling.result.result_group import ResultGroup
-from ml_tooling.metrics.metric import Metrics
 from ml_tooling.search.gridsearch import prepare_gridsearch_estimators
+from ml_tooling.storage.base import Storage
 from ml_tooling.utils import (
     MLToolingError,
     _validate_estimator,
@@ -30,6 +26,9 @@ from ml_tooling.utils import (
     make_pipeline_from_definition,
     read_yaml,
 )
+from sklearn.base import is_classifier, is_regressor
+from sklearn.exceptions import NotFittedError
+from sklearn.model_selection import check_cv
 
 logger = create_logger("ml_tooling")
 
@@ -142,7 +141,7 @@ class Model:
         logger.info(f"Loaded {instance.estimator_name}")
         return instance
 
-    def save_estimator(self, storage: Storage, prod=False) -> pathlib.Path:
+    def save_estimator(self, storage: Storage = None, prod=False) -> pathlib.Path:
         """
         Saves the estimator as a binary file.
 
@@ -170,6 +169,9 @@ class Model:
         pathlib.Path
             The path to where the estimator file was saved
         """
+        if storage is None:
+            storage = self.config.default_storage
+
         if prod:
             file_name = "production_model.pkl"
         else:

--- a/src/ml_tooling/config.py
+++ b/src/ml_tooling/config.py
@@ -1,5 +1,7 @@
 import pathlib
 
+from ml_tooling.storage import FileStorage
+
 BASE_PATH = pathlib.Path(__file__).parent
 CWD = pathlib.Path.cwd()
 
@@ -24,6 +26,10 @@ class DefaultConfig:
         self.RUN_DIR = RUN_DIR
         self.ESTIMATOR_DIR = ESTIMATOR_DIR
         self.LOG = False
+
+    @property
+    def default_storage(self):
+        return FileStorage(self.ESTIMATOR_DIR)
 
     def __repr__(self):
         attrs = "\n".join(

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -231,6 +231,21 @@ class TestBaseClass:
             classifier.estimator, "production_model.pkl", prod=True
         )
 
+    def test_save_estimator_uses_default_storage_if_no_storage_is_passed(
+        self, tmp_path: pathlib.Path, classifier: Model
+    ):
+        classifier.config.ESTIMATOR_DIR = tmp_path
+        classifier.save_estimator()
+
+        models = classifier.config.default_storage.get_list()
+        assert len(models) == 1
+        new_classifier = Model.load_estimator(
+            classifier.config.default_storage, models[0]
+        )
+        assert (
+            classifier.estimator.get_params() == new_classifier.estimator.get_params()
+        )
+
     @patch("ml_tooling.baseclass.import_path")
     def test_can_load_production_estimator(
         self, mock_path: MagicMock, open_estimator_pickle

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -713,9 +713,10 @@ class TestGridSearch:
             assert result.metrics.score == result.metrics[0].score
 
     def test_gridsearch_can_log_with_context_manager(
-        self, feature_union_classifier, train_iris_dataset
+        self, feature_union_classifier, train_iris_dataset, tmp_path
     ):
         classifier = Model(feature_union_classifier)
+        classifier.config.RUN_DIR = tmp_path
         with classifier.log("gridsearch_union_test"):
             _, _ = classifier.gridsearch(
                 train_iris_dataset, param_grid={"clf__penalty": ["l1", "l2"]}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
-from sklearn.linear_model import LinearRegression
-
 from ml_tooling import Model
 from ml_tooling.config import DefaultConfig
+from sklearn.linear_model import LinearRegression
 
 
 class TestConfig:
@@ -87,3 +86,9 @@ class TestConfig:
         log.config.CLASSIFIER_METRIC = "fowlkes_mallows_score"
         assert rf.config.CLASSIFIER_METRIC == "accuracy"
         assert log.config.CLASSIFIER_METRIC == "fowlkes_mallows_score"
+
+    def test_config_default_storage_points_to_cwd(self, base, tmp_path):
+        base.config.ESTIMATOR_DIR = tmp_path
+        result = base.config.default_storage
+
+        assert result.dir_path == tmp_path


### PR DESCRIPTION
Adds a default filestorage, used if no storage object is passed to `save_estimator`. Will always point to `DefaultConfig.ESTIMATOR_DIR' 

- [x] closes issue #401 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md
