### PR TITLE
Load_prediction now returns sensible column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Fixed typehints in Dataset
 - Dataset.create_train_test now takes a boolean `stratify` parameter.
 - Added default local filestorage when using `save_estimator`
+- The dataframe returned by `.make_prediction`now labels the columns in a more
+human friendly manner
 
 # v0.10.2
 - Fixed type inferences from data to sql in _load_data

--- a/docs/baseclass.rst
+++ b/docs/baseclass.rst
@@ -119,8 +119,8 @@ This will call the :meth:`~ml_tooling.data.Dataset.load_prediction_data` defined
 
     >>> customer_id = 42
     >>> linear.make_prediction(bostondata, customer_id)
-               0
-    0  25.203866
+       Prediction
+    0   25.203866
 
 :meth:`~ml_tooling.baseclass.Model.make_prediction` also has a parameter :code:`proba` which will return the
 underlying probabilities if working on a classification problem

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "matplotlib.sphinxext.plot_directive",
+    "sphinx_rtd_theme",
 ]
 
 intersphinx_mapping = {

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -259,13 +259,14 @@ class Model:
         try:
             if proba:
                 data = self.estimator.predict_proba(x)
+                columns = [f"Probability Class {col}" for col in range(data.shape[1])]
             else:
                 data = self.estimator.predict(x)
-
+                columns = ["Prediction"]
             if use_index:
-                prediction = pd.DataFrame(data=data, index=x.index)
+                prediction = pd.DataFrame(data=data, index=x.index, columns=columns)
             else:
-                prediction = pd.DataFrame(data=data)
+                prediction = pd.DataFrame(data=data, columns=columns)
 
             return prediction
 

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -69,6 +69,7 @@ class TestBaseClass:
         result = model.make_prediction(dataset, 0)
 
         assert result.shape == (1, 1)
+        assert result.columns.tolist() == ["Prediction"]
 
     def test_make_prediction_with_classification_sqldataset_works_as_expected(
         self, iris_sqldataset, loaded_iris_db
@@ -81,6 +82,7 @@ class TestBaseClass:
         result = model.make_prediction(dataset, 0, proba=True)
 
         assert result.shape == (1, 2)
+        assert result.columns.tolist() == ["Probability Class 0", "Probability Class 1"]
 
     def test_make_prediction_errors_if_asked_for_proba_without_predict_proba_method(
         self, train_iris_dataset


### PR DESCRIPTION
Update load_prediction to return a DataFrame with more human readable names

- [x] closes issue #350 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
