### PR TITLE
Dataset raises exception if empty data is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed typehints in Dataset
 - Dataset.create_train_test now takes a boolean `stratify` parameter.
 - Added default local filestorage when using `save_estimator`
+- Dataset now verifies that `load_training_data` and `load_prediction_data` do not return empty
 
 # v0.10.2
 - Fixed type inferences from data to sql in _load_data

--- a/src/ml_tooling/data/base_data.py
+++ b/src/ml_tooling/data/base_data.py
@@ -106,12 +106,14 @@ class Dataset(metaclass=abc.ABCMeta):
     def _load_training_data(self, *args, **kwargs) -> Tuple[pd.DataFrame, DataType]:
         x, y = self.load_training_data(*args, **kwargs)
         if x.empty:
-            raise DatasetError("Empty dataset returned by load_training_data")
+            raise DatasetError("An empty dataset was returned by load_training_data")
 
         return x, y
 
     def _load_prediction_data(self, *args, **kwargs) -> pd.DataFrame:
         pred_data = self.load_prediction_data(*args, **kwargs)
+        if pred_data.empty:
+            raise DatasetError("An empty dataset was returned by load_prediction_data")
         self.cached_data = pred_data
         return pred_data
 

--- a/src/ml_tooling/data/base_data.py
+++ b/src/ml_tooling/data/base_data.py
@@ -104,7 +104,11 @@ class Dataset(metaclass=abc.ABCMeta):
         return self.__class__.__name__
 
     def _load_training_data(self, *args, **kwargs) -> Tuple[pd.DataFrame, DataType]:
-        return self.load_training_data(*args, **kwargs)
+        x, y = self.load_training_data(*args, **kwargs)
+        if x.empty:
+            raise DatasetError("Empty dataset returned by load_training_data")
+
+        return x, y
 
     def _load_prediction_data(self, *args, **kwargs) -> pd.DataFrame:
         pred_data = self.load_prediction_data(*args, **kwargs)

--- a/src/ml_tooling/data/sql.py
+++ b/src/ml_tooling/data/sql.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from ml_tooling.data.base_data import Dataset
 from ml_tooling.utils import DataType, DatasetError
 
-
 logger = logging.getLogger("ml_tooling")
 
 
@@ -102,7 +101,10 @@ class SQLDataset(Dataset, metaclass=abc.ABCMeta):
 
     def _load_training_data(self, *args, **kwargs) -> Tuple[pd.DataFrame, DataType]:
         with self.create_connection() as conn:
-            return self.load_training_data(*args, conn=conn, **kwargs)
+            x, y = self.load_training_data(*args, conn=conn, **kwargs)
+            if x.empty:
+                raise DatasetError("Empty dataset returned by load_training_data")
+            return x, y
 
     def _load_prediction_data(self, *args, **kwargs) -> pd.DataFrame:
         with self.create_connection() as conn:

--- a/src/ml_tooling/data/sql.py
+++ b/src/ml_tooling/data/sql.py
@@ -101,16 +101,11 @@ class SQLDataset(Dataset, metaclass=abc.ABCMeta):
 
     def _load_training_data(self, *args, **kwargs) -> Tuple[pd.DataFrame, DataType]:
         with self.create_connection() as conn:
-            x, y = self.load_training_data(*args, conn=conn, **kwargs)
-            if x.empty:
-                raise DatasetError("Empty dataset returned by load_training_data")
-            return x, y
+            return super()._load_training_data(*args, conn=conn, **kwargs)
 
     def _load_prediction_data(self, *args, **kwargs) -> pd.DataFrame:
         with self.create_connection() as conn:
-            pred_data = self.load_prediction_data(*args, conn=conn, **kwargs)
-            self.cached_data = pred_data
-            return pred_data
+            return super()._load_prediction_data(*args, conn=conn, **kwargs)
 
     def _dump_data(self) -> pd.DataFrame:
         """

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -481,7 +481,7 @@ class TestTrainEstimator:
                 self.average = None
 
             def fit(self, x, y=None):
-                self.average = np.mean(x, axis=1)
+                self.average = np.mean(x, axis=0)
                 return self
 
             def predict(self, x):
@@ -489,10 +489,10 @@ class TestTrainEstimator:
 
         class DummyData(Dataset):
             def load_training_data(self):
-                return np.array([[1, 2, 3, 4], [4, 5, 6, 7]]), None
+                return pd.DataFrame({"col1": [1, 2, 3, 4], "col2": [4, 5, 6, 7]}), None
 
             def load_prediction_data(self, *args, **kwargs):
-                return np.array([[1, 2, 3, 4], [4, 5, 6, 7]])
+                return pd.DataFrame({"col1": [1, 2, 3, 4], "col2": [4, 5, 6, 7]})
 
         model = Model(DummyEstimator())
         data = DummyData()


### PR DESCRIPTION
- [x] closes #235 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md

Adds a check to `load_prediction_data` and `load_training_data` which raises a DatasetError if an empty DataFrame is returned