### PR TITLE
Dataset cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ human friendly manner
 - Dataset now verifies that `load_training_data` and `load_prediction_data` do not return empty
 - Added a missing data visualization to `Dataset.plot`
 - FillNA now accepts a `is_nan`flag which adds a flag indicating that a value was missing
+- `Model.make_prediction` now accepts a `use_cache`flag to score everything in cached `.x`
 
 # v0.10.2
 - Fixed type inferences from data to sql in _load_data

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -227,6 +227,7 @@ class Model:
         *args,
         proba: bool = False,
         use_index: bool = False,
+        use_cache: bool = False,
         **kwargs,
     ) -> pd.DataFrame:
         """
@@ -246,6 +247,10 @@ class Model:
         use_index: bool
             Whether the index from the prediction data should be used for the result.
 
+        use_cache: bool
+            Whether or not to use the cached data in dataset to make predictions.
+            Useful for seeing probability distributions of the model
+
         Returns
         -------
         pd.DataFrame
@@ -255,7 +260,9 @@ class Model:
             raise MLToolingError(
                 f"{self.estimator_name} does not have a `predict_proba` method"
             )
-        x = data._load_prediction_data(*args, **kwargs)
+
+        x = data.x if use_cache else data._load_prediction_data(*args, **kwargs)
+
         try:
             if proba:
                 data = self.estimator.predict_proba(x)

--- a/src/ml_tooling/data/sql.py
+++ b/src/ml_tooling/data/sql.py
@@ -107,7 +107,7 @@ class SQLDataset(Dataset, metaclass=abc.ABCMeta):
         with self.create_connection() as conn:
             return super()._load_prediction_data(*args, conn=conn, **kwargs)
 
-    def _dump_data(self) -> pd.DataFrame:
+    def _dump_data(self, use_cache=False) -> pd.DataFrame:
         """
         Reads the underlying SQL table and returns a DataFrame
 
@@ -116,6 +116,7 @@ class SQLDataset(Dataset, metaclass=abc.ABCMeta):
         pd.DataFrame
 
         """
+
         logger.info(f"Dumping data from {self.table}")
         logger.debug(f"Dumping data from {self.engine}/{self.table.name}")
         stmt = sa.select([self.table])


### PR DESCRIPTION
Adds a `use_cache` flag to `Model.make_prediction` to allow `make_prediction` to use the dataset cache to make the prediction. 

Useful for examining prediction distributions for the dataset

- [x] closes #441 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
