### PR TITLE
Update pre-commit to separate out flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,20 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-      - id: flake8
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: forbid-new-submodules
       - id: no-commit-to-branch
         args: [--branch, master, --branch, develop]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8


### PR DESCRIPTION
Flake8 is no longer part of the default hooks
 Minor devtooling change