### PR TITLE
Set tox docs environment to fail on warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ passenv =
     http_proxy
     https_proxy
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     python -m doctest README.md
 


### PR DESCRIPTION
We want docs to fail on warnings so that we are alerted to them. It should not be a blocker for develop, but for master it should be required