### PR TITLE
Update all tests to close all matplotlib figures when testing

### DIFF
--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -337,6 +337,7 @@ class TestFeatureImportancePlot:
         data = IrisData().create_train_test()
         result = Model(RandomForestClassifier(n_estimators=2)).score_estimator(data)
         assert result.plot.feature_importance()
+        plt.close()
 
     def test_can_use_different_scoring_metrics(self, classifier: Model):
         ax = classifier.result.plot.feature_importance(
@@ -349,6 +350,7 @@ class TestFeatureImportancePlot:
             ax.get_xlabel()
             == "Permuted Feature Importance (Roc_Auc) Relative to Baseline"
         )
+        plt.close()
 
     def test_can_use_feature_importance_with_regressor(self, regression: Model):
         ax = regression.result.plot.feature_importance()
@@ -356,6 +358,7 @@ class TestFeatureImportancePlot:
         assert (
             ax.get_xlabel() == "Permuted Feature Importance (R2) Relative to Baseline"
         )
+        plt.close()
 
     def test_plot_feature_importance_with_default_metrics(self, classifier: Model):
         ax = plot_feature_importance(
@@ -367,6 +370,7 @@ class TestFeatureImportancePlot:
             ax.get_xlabel()
             == "Permuted Feature Importance (Accuracy) Relative to Baseline"
         )
+        plt.close()
 
 
 class TestLiftCurvePlot:
@@ -393,6 +397,7 @@ class TestLiftCurvePlot:
         proba = clf.predict_proba(x)
         with pytest.raises(VizError):
             plot_lift_curve(y, proba)
+        plt.close()
 
 
 class TestPredictionErrorPlot:
@@ -463,6 +468,7 @@ class TestRocCurve:
         result = svc.score_estimator(train_iris_dataset)
         with pytest.raises(VizError):
             result.plot.roc_curve()
+        plt.close()
 
 
 class TestPRCurve:
@@ -521,6 +527,7 @@ class TestLearningCurve:
             test_ax.lines[0].get_xdata().max()
             == (len(classifier.result.data.train_x) * 4) // 5
         )
+        plt.close()
 
     def test_learning_curve_can_use_different_scoring_parameters(
         self, classifier: Model
@@ -529,6 +536,7 @@ class TestLearningCurve:
         assert test_ax.get_ylabel() == "Roc_Auc Score"
         assert test_ax.get_legend().texts[0].get_text() == "Training Roc_Auc"
         assert test_ax.get_legend().texts[1].get_text() == "Cross-validated Roc_Auc"
+        plt.close()
 
 
 class TestValidationCurve:
@@ -552,12 +560,14 @@ class TestValidationCurve:
         assert test_ax.lines[0].get_xdata().min() == 0.001
         assert test_ax.get_legend().texts[0].get_text() == "Training Accuracy"
         assert test_ax.get_legend().texts[1].get_text() == "Test Accuracy"
+        plt.close()
 
     def test_validation_curve_plot_can_multiprocess(self, classifier: Model):
         param_range = [0.001, 0.01, 0.01, 0.1, 1]
         assert classifier.result.plot.validation_curve(
             param_name="C", param_range=param_range, n_jobs=-1
         )
+        plt.close()
 
     def test_validation_curve_can_plot_other_metrics(self, classifier: Model):
         param_range = [0.001, 0.01, 0.01, 0.1, 1]
@@ -568,6 +578,7 @@ class TestValidationCurve:
         assert test_ax.get_ylabel() == "Roc_Auc Score"
         assert test_ax.get_legend().texts[0].get_text() == "Training Roc_Auc"
         assert test_ax.get_legend().texts[1].get_text() == "Test Roc_Auc"
+        plt.close()
 
 
 class TestTargetCorrelation:
@@ -580,6 +591,7 @@ class TestTargetCorrelation:
             "0.12",
             "-0.48",
         ]
+        plt.close()
 
     def test_target_correlation_uses_pipeline_when_passed(
         self, train_iris_dataset: Dataset
@@ -589,6 +601,7 @@ class TestTargetCorrelation:
 
         train_iris_dataset.plot.target_correlation(feature_pipeline=mock)
         mock.fit_transform.assert_called_once_with(train_iris_dataset.x)
+        plt.close()
 
     def test_target_correlation_works_as_expected(self, train_iris_dataset):
         ax = train_iris_dataset.plot.target_correlation()
@@ -603,6 +616,7 @@ class TestTargetCorrelation:
         assert ax.title.get_text() == "Feature-Target Correlation"
         assert ax.get_xlabel() == "Spearman Correlation"
         assert ax.get_ylabel() == "Feature Labels"
+        plt.close()
 
     def test_target_correlation_works_with_different_methods(self, train_iris_dataset):
         ax = train_iris_dataset.plot.target_correlation(method="pearson")
@@ -616,6 +630,7 @@ class TestTargetCorrelation:
         assert ax.title.get_text() == "Feature-Target Correlation"
         assert ax.get_xlabel() == "Pearson Correlation"
         assert ax.get_ylabel() == "Feature Labels"
+        plt.close()
 
     def test_target_correlation_works_with_top_n(self, train_iris_dataset):
         ax = train_iris_dataset.plot.target_correlation(top_n=2)
@@ -623,6 +638,7 @@ class TestTargetCorrelation:
         assert ax.title.get_text() == "Feature-Target Correlation - Top 2"
         assert ax.get_xlabel() == "Spearman Correlation"
         assert ax.get_ylabel() == "Feature Labels"
+        plt.close()
 
     def test_target_correlation_works_with_bottom_n(self, train_iris_dataset):
         ax = train_iris_dataset.plot.target_correlation(bottom_n=2)
@@ -630,6 +646,7 @@ class TestTargetCorrelation:
         assert ax.title.get_text() == "Feature-Target Correlation - Bottom 2"
         assert ax.get_xlabel() == "Spearman Correlation"
         assert ax.get_ylabel() == "Feature Labels"
+        plt.close()
 
     def test_target_correlation_works_with_bottom_n_and_top_n(self, train_iris_dataset):
         ax = train_iris_dataset.plot.target_correlation(bottom_n=1, top_n=1)
@@ -637,6 +654,7 @@ class TestTargetCorrelation:
         assert ax.title.get_text() == "Feature-Target Correlation - Top 1 - Bottom 1"
         assert ax.get_xlabel() == "Spearman Correlation"
         assert ax.get_ylabel() == "Feature Labels"
+        plt.close()
 
     def test_target_correlation_plots_can_be_given_an_ax(self, train_iris_dataset):
         fig, ax = plt.subplots()
@@ -655,12 +673,14 @@ class TestMissingDataViz:
     def ax(self, missing_data):
         axis = missing_data.plot.missing_data()
         axis.figure.canvas.draw()
-        return axis
+        yield axis
+        plt.close()
 
     def test_missing_data_can_pass_pipeline(self, missing_data: Dataset):
         pipeline = Pipeline([("scaler", DFStandardScaler())])
         ax = missing_data.plot.missing_data(feature_pipeline=pipeline)
         assert [text.get_text() for text in ax.texts] == ["2.0%"]
+        plt.close()
 
     def test_target_correlation_uses_pipeline_when_passed(
         self, train_iris_dataset: Dataset
@@ -670,6 +690,7 @@ class TestMissingDataViz:
 
         train_iris_dataset.plot.target_correlation(feature_pipeline=mock)
         mock.fit_transform.assert_called_once_with(train_iris_dataset.x)
+        plt.close()
 
     def test_missing_data_text_labels_are_correct(self, ax):
         assert [text.get_text() for text in ax.texts] == ["2.0%"]
@@ -701,3 +722,4 @@ class TestMissingDataViz:
     def test_can_call_missing_data_with_no_missing_values(self, train_boston_dataset):
         ax = train_boston_dataset.plot.missing_data()
         assert ax.patches == []
+        plt.close()


### PR DESCRIPTION
Tests were issuing warnings about too many open matplotlib plots
Calls plt.close in all tests involving plotting