### PR TITLE
Refactored hyperparameter search as a generic Searcher interface

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile dev-requirements.in
 #
+--index-url http://artifactory-singlep.p001.alm.brand.dk/artifactory/api/pypi/pypi-virtual/simple
+--trusted-host artifactory-singlep.p001.alm.brand.dk
 
 appdirs==1.4.4            # via virtualenv
 attrs==19.3.0             # via -r requirements.txt, pytest
@@ -15,7 +17,7 @@ cycler==0.10.0            # via -r requirements.txt, matplotlib
 distlib==0.3.1            # via virtualenv
 dohq-artifactory==0.7.379  # via -r dev-requirements.in
 filelock==3.0.12          # via tox, virtualenv
-identify==1.4.23          # via pre-commit
+identify==1.4.25          # via pre-commit
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via pluggy, pre-commit, pytest, tox, virtualenv
 joblib==0.16.0            # via -r requirements.txt, scikit-learn
@@ -23,7 +25,7 @@ kiwisolver==1.2.0         # via -r requirements.txt, matplotlib
 matplotlib==3.3.0         # via -r requirements.txt
 more-itertools==8.4.0     # via pytest
 nodeenv==1.4.0            # via pre-commit
-numpy==1.19.0             # via -r requirements.txt, matplotlib, pandas, scikit-learn, scipy
+numpy==1.19.1             # via -r requirements.txt, matplotlib, pandas, scikit-learn, scipy
 packaging==20.4           # via pytest, tox
 pandas==1.0.5             # via -r requirements.txt
 pillow==7.2.0             # via -r requirements.txt, matplotlib

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -62,7 +62,7 @@ each other using different metrics. The best estimator is then picked using the 
     >>> from sklearn.dummy import DummyClassifier
     >>> estimators = [LogisticRegression(solver='lbfgs'),
     ...               RandomForestClassifier(n_estimators=10, random_state=42),
-    ...               DummyClassifier(random_state=42)]
+    ...               DummyClassifier(strategy="prior", random_state=42)]
     >>> best_model, results = Model.test_estimators(data, estimators, metrics=['accuracy', 'roc_auc'], cv=10)
 
 We can see that the results are sorted and shows us a nice repr of each model's performance
@@ -85,7 +85,7 @@ context manager, passing a log_directory where to save the files.
     ...     best_model, results = rf_clf.gridsearch(data, {"max_depth": [3, 5, 10, 15]})
     >>>
     >>> results
-    ResultGroup(results=[<Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.93}>])
+    ResultGroup(results=[<Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.95}>, <Result RandomForestClassifier: {'accuracy': 0.95}>])
 
 .. testcleanup::
 

--- a/src/ml_tooling/result/result.py
+++ b/src/ml_tooling/result/result.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import attr
 from sklearn.base import is_classifier
 
@@ -46,12 +48,18 @@ class Result:
         return model
 
     @classmethod
-    def from_model(
-        cls, model, data: Dataset, metrics: Metrics, cv=None, n_jobs=None, verbose=None
+    def from_estimator(
+        cls,
+        estimator: Estimator,
+        data: Dataset,
+        metrics: Metrics,
+        cv: Any = None,
+        n_jobs: int = None,
+        verbose: int = 0,
     ) -> "Result":
         if cv:
             metrics.score_metrics_cv(
-                estimator=model.estimator,
+                estimator=estimator,
                 x=data.train_x,
                 y=data.train_y,
                 cv=cv,
@@ -59,11 +67,9 @@ class Result:
                 verbose=verbose,
             )
         else:
-            metrics.score_metrics(
-                estimator=model.estimator, x=data.test_x, y=data.test_y
-            )
+            metrics.score_metrics(estimator=estimator, x=data.test_x, y=data.test_y)
 
-        return cls(metrics=metrics, estimator=model.estimator, data=data)
+        return cls(metrics=metrics, estimator=estimator, data=data)
 
     def log(self, saved_estimator_path=None, savedir=None) -> Log:
         log = Log.from_result(result=self, estimator_path=saved_estimator_path)

--- a/src/ml_tooling/search/__init__.py
+++ b/src/ml_tooling/search/__init__.py
@@ -1,0 +1,4 @@
+from .gridsearch import GridSearch
+from .randomsearch import RandomSearch
+
+__all__ = ["GridSearch", "RandomSearch"]

--- a/src/ml_tooling/search/base.py
+++ b/src/ml_tooling/search/base.py
@@ -1,0 +1,41 @@
+from typing import List, Any, Iterable
+
+from ml_tooling.data import Dataset
+from ml_tooling.metrics import Metrics
+from ml_tooling.result import ResultGroup, Result
+from ml_tooling.utils import Estimator
+
+
+class Searcher:
+    def __init__(self, estimator: Estimator, param_grid: dict):
+        self.estimator = estimator
+        self.param_grid = param_grid
+
+    @staticmethod
+    def _train_estimators(
+        estimators: Iterable[Estimator],
+        metrics: List[str],
+        data: Dataset,
+        n_jobs: int,
+        cv: Any,
+        verbose: int,
+    ):
+        metrics = Metrics.from_list(metrics)
+        results = [
+            Result.from_estimator(
+                estimator=estimator,
+                metrics=metrics,
+                data=data,
+                cv=cv,
+                n_jobs=n_jobs,
+                verbose=verbose,
+            )
+            for estimator in estimators
+        ]
+
+        return ResultGroup(results).sort()
+
+    def search(
+        self, data: Dataset, metrics: List[str], cv: Any, n_jobs: int, verbose: int = 0
+    ) -> ResultGroup:
+        raise NotImplementedError

--- a/src/ml_tooling/search/gridsearch.py
+++ b/src/ml_tooling/search/gridsearch.py
@@ -1,13 +1,28 @@
-from typing import Iterator
+from typing import Iterator, List, Any
 
 from sklearn import clone
 from sklearn.model_selection import ParameterGrid
 
+from ml_tooling.data import Dataset
+from ml_tooling.result import ResultGroup
+from ml_tooling.search.base import Searcher
 from ml_tooling.utils import Estimator
 
 
-def prepare_gridsearch_estimators(
-    estimator: Estimator, params: dict
-) -> Iterator[Estimator]:
-    grid = ParameterGrid(params)
-    yield from (clone(estimator).set_params(**p) for p in grid)
+class GridSearch(Searcher):
+    def prepare_gridsearch_estimators(self) -> Iterator[Estimator]:
+        grid = ParameterGrid(self.param_grid)
+        yield from (clone(self.estimator).set_params(**p) for p in grid)
+
+    def search(
+        self, data: Dataset, metrics: List[str], cv: Any, n_jobs: int, verbose: int = 0
+    ) -> ResultGroup:
+        estimators = self.prepare_gridsearch_estimators()
+        return self._train_estimators(
+            estimators,
+            metrics=metrics,
+            data=data,
+            n_jobs=n_jobs,
+            cv=cv,
+            verbose=verbose,
+        )

--- a/src/ml_tooling/search/randomsearch.py
+++ b/src/ml_tooling/search/randomsearch.py
@@ -1,13 +1,35 @@
-from typing import Iterator
+from typing import Iterator, List, Any
 
 from sklearn import clone
 from sklearn.model_selection import ParameterSampler
 
+from ml_tooling.config import config
+from ml_tooling.data import Dataset
+from ml_tooling.result import ResultGroup
+from ml_tooling.search.base import Searcher
 from ml_tooling.utils import Estimator
 
 
-def prepare_randomsearch_estimators(
-    estimator: Estimator, params: dict, n_iter: int = 10, random_state=1337
-) -> Iterator[Estimator]:
-    grid = ParameterSampler(params, n_iter=n_iter, random_state=random_state)
-    yield from (clone(estimator).set_params(**p) for p in grid)
+class RandomSearch(Searcher):
+    def __init__(self, estimator: Estimator, param_grid: dict, n_iter: int = 10):
+        super().__init__(estimator, param_grid)
+        self.n_iter = n_iter
+
+    def prepare_randomsearch_estimators(self) -> Iterator[Estimator]:
+        grid = ParameterSampler(
+            self.param_grid, n_iter=self.n_iter, random_state=config.RANDOM_STATE
+        )
+        yield from (clone(self.estimator).set_params(**p) for p in grid)
+
+    def search(
+        self, data: Dataset, metrics: List[str], cv: Any, n_jobs: int, verbose: int = 0
+    ) -> ResultGroup:
+        estimators = self.prepare_randomsearch_estimators()
+        return self._train_estimators(
+            estimators,
+            metrics=metrics,
+            data=data,
+            n_jobs=n_jobs,
+            cv=cv,
+            verbose=verbose,
+        )

--- a/tests/fixtures/estimators.py
+++ b/tests/fixtures/estimators.py
@@ -45,21 +45,27 @@ def classifier_cv(train_iris_dataset) -> Model:
 @pytest.fixture
 def pipeline_logistic() -> Pipeline:
     pipe = Pipeline(
-        [("scale", StandardScaler()), ("clf", LogisticRegression(solver="liblinear"))]
+        [
+            ("scale", StandardScaler()),
+            ("estimator", LogisticRegression(solver="liblinear")),
+        ]
     )
     return pipe
 
 
 @pytest.fixture
 def pipeline_linear() -> Pipeline:
-    pipe = Pipeline([("scale", StandardScaler()), ("clf", LinearRegression())])
+    pipe = Pipeline([("scale", StandardScaler()), ("estimator", LinearRegression())])
     return pipe
 
 
 @pytest.fixture
 def pipeline_dummy_classifier() -> Pipeline:
     pipe = Pipeline(
-        [("scale", DFStandardScaler()), ("clf", DummyClassifier(strategy="prior"))]
+        [
+            ("scale", DFStandardScaler()),
+            ("estimator", DummyClassifier(strategy="prior")),
+        ]
     )
     return pipe
 
@@ -80,7 +86,7 @@ def feature_union_classifier() -> Pipeline:
     )
     union = DFFeatureUnion(transformer_list=[("pipe1", pipe1), ("pipe2", pipe2)])
     return Pipeline(
-        [("features", union), ("clf", LogisticRegression(solver="liblinear"))]
+        [("features", union), ("estimator", LogisticRegression(solver="liblinear"))]
     )
 
 
@@ -89,7 +95,7 @@ def pipeline_forest_classifier() -> Pipeline:
     pipe = Pipeline(
         [
             ("scale", DFStandardScaler()),
-            ("clf", RandomForestClassifier(n_estimators=10)),
+            ("estimator", RandomForestClassifier(n_estimators=10)),
         ]
     )
     return pipe

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -92,11 +92,15 @@ class TestResultGroup:
     def test_result_group_proxies_correctly(
         self, train_iris_dataset, classifier: Model, classifier_cv: Model
     ):
-        result1 = Result.from_model(
-            classifier, train_iris_dataset, metrics=Metrics([Metric("accuracy")])
+        result1 = Result.from_estimator(
+            classifier.estimator,
+            train_iris_dataset,
+            metrics=Metrics([Metric("accuracy")]),
         )
-        result2 = Result.from_model(
-            classifier_cv, train_iris_dataset, metrics=Metrics([Metric("accuracy")])
+        result2 = Result.from_estimator(
+            classifier_cv.estimator,
+            train_iris_dataset,
+            metrics=Metrics([Metric("accuracy")]),
         )
 
         group = ResultGroup([result1, result2])
@@ -106,14 +110,14 @@ class TestResultGroup:
     def test_result_group_implements_indexing_properly(
         self, train_iris_dataset, classifier: Model
     ):
-        result1 = Result.from_model(
-            model=classifier,
+        result1 = Result.from_estimator(
+            estimator=classifier.estimator,
             data=train_iris_dataset,
             metrics=Metrics.from_list(["accuracy"]),
         )
 
-        result2 = Result.from_model(
-            model=classifier,
+        result2 = Result.from_estimator(
+            estimator=classifier.estimator,
             data=train_iris_dataset,
             metrics=Metrics.from_list(["accuracy"]),
         )
@@ -127,13 +131,13 @@ class TestResultGroup:
         self, tmp_path: pathlib.Path, train_iris_dataset, classifier: Model
     ):
         runs = tmp_path / "runs"
-        result1 = Result.from_model(
-            model=classifier,
+        result1 = Result.from_estimator(
+            estimator=classifier.estimator,
             data=train_iris_dataset,
             metrics=Metrics.from_list(["accuracy"]),
         )
-        result2 = Result.from_model(
-            model=classifier,
+        result2 = Result.from_estimator(
+            estimator=classifier.estimator,
             data=train_iris_dataset,
             metrics=Metrics.from_list(["accuracy"]),
         )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,88 @@
+import pytest
+from sklearn.pipeline import Pipeline
+from sklearn.model_selection import KFold
+
+from ml_tooling.data import Dataset
+from ml_tooling.search import GridSearch, RandomSearch
+from scipy.stats.distributions import randint
+from itertools import product
+
+
+class TestGridSearch:
+    """Tests covering the GridSearch searcher"""
+
+    @pytest.fixture()
+    def grid(self, pipeline_forest_classifier: Pipeline) -> GridSearch:
+        """Setup a GridSearch object"""
+        return GridSearch(
+            pipeline_forest_classifier, param_grid={"estimator__max_depth": [1, 2, 3]}
+        )
+
+    def test_prepare_gridsearch_estimators_has_different_parameters(self, grid):
+        """Expect that each estimator has a different max_depth"""
+        estimators = grid.prepare_gridsearch_estimators()
+
+        for estimator, penalty in zip(estimators, [1, 2, 3]):
+            assert estimator.get_params()["estimator__max_depth"] == penalty
+
+    def test_grid_can_take_a_cv_object(
+        self, grid: GridSearch, train_iris_dataset: Dataset
+    ):
+        """Expect that grid will use a given CV splitter if passed"""
+        cv = KFold(n_splits=2)
+        results = grid.search(
+            train_iris_dataset, metrics=["accuracy"], cv=cv, n_jobs=-1
+        )
+        assert len(results[0].metrics[0].cross_val_scores) == 2
+
+    def test_grid_returns_correct_number_of_results(
+        self, grid, train_iris_dataset: Dataset
+    ):
+        """Expect that grid will return 3 results, one for each parameter"""
+        results = grid.search(train_iris_dataset, metrics=["accuracy"], cv=2, n_jobs=-1)
+        assert len(results) == 3
+
+
+class TestRandomSearch:
+    """Tests covering the RandomSearch searcher"""
+
+    @pytest.fixture()
+    def grid(self, pipeline_forest_classifier: Pipeline):
+        """Setup a RandomSearch searcher"""
+        return RandomSearch(
+            pipeline_forest_classifier,
+            param_grid={
+                "estimator__max_depth": randint(0, 100),
+                "estimator__criterion": ["gini", "entropy"],
+            },
+            n_iter=2,
+        )
+
+    def test_random_search_has_different_hyperparams(
+        self, grid: RandomSearch, train_iris_dataset: Dataset
+    ):
+        """
+        Expect that the randomsearch estimators will have different hyperparameters
+        each time the estimators are built
+        """
+        estimators = [grid.prepare_randomsearch_estimators() for _ in range(5)]
+        for a, b in zip(estimators, estimators[1:]):
+            for estimator_a, estimator_b in product(a, b):
+                assert estimator_a.get_params() != estimator_b.get_params()
+
+    def test_random_search_can_take_a_cv_object(
+        self, grid: RandomSearch, train_iris_dataset: Dataset
+    ):
+        """Expect that RandomSearch will use a given CV splitter if passed"""
+        cv = KFold(n_splits=2)
+        results = grid.search(
+            train_iris_dataset, metrics=["accuracy"], cv=cv, n_jobs=-1
+        )
+        assert len(results[0].metrics[0].cross_val_scores) == 2
+
+    def test_random_search_returns_correct_number_of_results(
+        self, grid: RandomSearch, train_iris_dataset: Dataset
+    ):
+        """Expect that RandomSearch will return 2 results, equal to n_iter"""
+        results = grid.search(train_iris_dataset, metrics=["accuracy"], cv=2, n_jobs=-1)
+        assert len(results) == grid.n_iter


### PR DESCRIPTION
All hyperparameter searching now happen in a Searcher instance which implements
the necessary logic

This is a prerequisite for being able to implement other Hyperparameter searchers such as Bayes or Hyperband
