### PR TITLE
Add support for pyproject.toml when saving production estimators

### DIFF
--- a/src/ml_tooling/utils.py
+++ b/src/ml_tooling/utils.py
@@ -319,8 +319,12 @@ def _find_setup_file(path: pathlib.Path, level: int, max_level: int) -> pathlib.
     """
     if level > max_level:
         raise MLToolingError("Exceeded max_level. Does your project have a setup.py?")
-    if path.joinpath("setup.py").exists():
-        return path
+
+    package_files = ["setup.py", "pyproject.toml"]
+
+    for package_file in package_files:
+        if path.joinpath(package_file).exists():
+            return path
 
     return _find_setup_file(path.parent, level + 1, max_level)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,10 @@ def monkeypatch_git_hash(monkeypatch):
     monkeypatch.setattr("ml_tooling.utils.get_git_hash", mockreturn)
 
 
-@pytest.fixture
-def temp_project_structure(tmp_path: pathlib.Path) -> pathlib.Path:
+@pytest.fixture(params=["setup.py", "pyproject.toml"])
+def temp_project_structure(tmp_path: pathlib.Path, request) -> pathlib.Path:
     # Write a setup.py file
-    tmp_path.joinpath("setup.py").write_text("my_setup\nfile")
+    tmp_path.joinpath(request.param).write_text("my_setup\nfile")
 
     # Setup a src project
     project = tmp_path.joinpath("src").joinpath("my_test_project")


### PR DESCRIPTION
Simple fix to allow for using poetry when saving production estimators
