### PR TITLE
Fix bug where plotting confusion matrix had a wrong default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implemented Bayesian Search for hyperparameter optimization
 - Added a `read_file` convenience method to `FileDataset` to read
 - Fixed a bug where `copy_to` failed between two instances of Sqlite based SQLDatasets
+- Fixed a bug where `ClassificationVisualize.confusion_matrix` would fail on multi-class problems due to wrong defaults
 
 # v0.11.0
 - Added `load_demo_dataset` function

--- a/src/ml_tooling/plots/viz/classification_viz.py
+++ b/src/ml_tooling/plots/viz/classification_viz.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from matplotlib import pyplot as plt
 
 from ml_tooling.plots import (
@@ -17,7 +19,7 @@ class ClassificationVisualize(BaseVisualize):
     """
 
     def confusion_matrix(
-        self, normalized: bool = True, threshold: float = 0.5, **kwargs
+        self, normalized: bool = True, threshold: Optional[float] = None, **kwargs
     ) -> plt.Axes:
         """
         Visualize a confusion matrix for a classification estimator


### PR DESCRIPTION
Fixes bug where plotting a confusion matrix with multiple classes would fail, as `ClassificationVisualize.confusion_matrix` had `threshold` set to a default of 0.5 instead of None
