### PR TITLE
Feature/add default storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - ROC AUC curve can now plot multi-class
 - Fixed Binner to have a default value
 - Fixed FuncTransform to have a default value
+- `load_estimator` now uses default storage if nothing is passed
 
 # v0.11.0
 - Added `load_demo_dataset` function

--- a/docs/baseclass.rst
+++ b/docs/baseclass.rst
@@ -274,7 +274,7 @@ We can also load the model from a storage by specifying the filename to load in 
 
 .. doctest::
 
-    >>> loaded_linear = linear.load_estimator(storage, estimator_path.name)
+    >>> loaded_linear = linear.load_estimator(estimator_path.name, storage=storage)
     >>> loaded_linear
     <Model: LinearRegression>
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -86,7 +86,7 @@ We can save and load our model:
     >>> from ml_tooling.storage import FileStorage
     >>> storage = FileStorage('./estimator_dir')
     >>> file_path = regression.save_estimator(storage)
-    >>> my_new_model = regression.load_estimator(storage, file_path.name)
+    >>> my_new_model = regression.load_estimator(file_path.name, storage=storage)
     >>> my_new_model
     <Model: LinearRegression>
 

--- a/docs/transformers.rst
+++ b/docs/transformers.rst
@@ -178,6 +178,7 @@ Example
 -------
 
 Here we want to bin our sales data into 3 buckets
+
 .. doctest::
 
     >>> from ml_tooling.transformers import Binner
@@ -240,6 +241,7 @@ Converts a column into a normalized frequency
 
 Example
 #######
+
 .. doctest::
 
     >>> from ml_tooling.transformers import FreqFeature

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -132,7 +132,9 @@ class Model:
         return storage.get_list()
 
     @classmethod
-    def load_estimator(cls, storage: Storage, path: pathlib.Path) -> "Model":
+    def load_estimator(
+        cls, path: Union[str, pathlib.Path], storage: Storage = None
+    ) -> "Model":
         """
         Instantiates the class with a joblib pickled estimator.
 
@@ -140,7 +142,8 @@ class Model:
         ----------
         storage : Storage
             Storage class to load the estimator with
-        path: str, optional
+
+        path: str, pathlib.Path, optional
             Path to estimator pickle file
 
         Example
@@ -148,17 +151,24 @@ class Model:
         We can load a trained estimator from disk::
 
             storage = FileStorage('path/to/dir')
-            my_estimator = Model.load_estimator(storage, 'my_model.pkl')
+            my_estimator = Model.load_estimator('my_model.pkl', storage=storage)
 
         We now have a trained estimator loaded.
+
+        We can also use the default storage::
+
+            my_estimator = Model.load_estimator('my_model.pkl')
+
+        This will use the default FileStorage defined in Model.config.default_storage
 
         Returns
         -------
         Model
             Instance of Model with a saved estimator
         """
+        fs = config.default_storage if storage is None else storage
         filename = pathlib.Path(path).name
-        estimator = storage.load(filename)
+        estimator = fs.load(filename)
         instance = cls(estimator)
         logger.info(f"Loaded {instance.estimator_name}")
         return instance

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -123,7 +123,7 @@ class TestBaseClass:
         storage = FileStorage(tmp_path)
         saved_model_path = classifier.save_estimator(storage)
         assert saved_model_path.exists()
-        loaded_model = classifier.load_estimator(load_storage, saved_model_path)
+        loaded_model = classifier.load_estimator(saved_model_path, storage=load_storage)
         assert loaded_model.estimator.get_params() == classifier.estimator.get_params()
 
     def test_regression_model_filename_is_generated_correctly(
@@ -150,7 +150,7 @@ class TestBaseClass:
     ):
         mock_hash.return_value = "1234"
 
-        with classifier.log(tmp_path):
+        with classifier.log(str(tmp_path)):
             expected_file = classifier.save_estimator(FileStorage(tmp_path))
 
         assert expected_file.exists()
@@ -175,9 +175,7 @@ class TestBaseClass:
 
         models = classifier.config.default_storage.get_list()
         assert len(models) == 1
-        new_classifier = Model.load_estimator(
-            classifier.config.default_storage, models[0]
-        )
+        new_classifier = Model.load_estimator(models[0])
         assert (
             classifier.estimator.get_params() == new_classifier.estimator.get_params()
         )
@@ -625,7 +623,7 @@ class TestModelSelection:
             train_iris_dataset, estimators, cv=2, refit=True, metrics="accuracy"
         )
 
-        assert (model.coef_ == model2.estimator.coef_).all()
+        assert np.all(model.coef_ == model2.estimator.coef_)
 
 
 class TestGridSearch:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -43,10 +43,12 @@ class TestFileStorage:
         storage = FileStorage(tmp_path)
         expected_file = classifier.save_estimator(storage)
         assert expected_file.exists()
-        loaded_file = classifier.load_estimator(storage, expected_file)
+        loaded_file = classifier.load_estimator(expected_file, storage=storage)
         assert isinstance(loaded_file, Model)
         storage_context = FileStorage(tmp_path)
-        context_loaded_file = classifier.load_estimator(storage_context, expected_file)
+        context_loaded_file = classifier.load_estimator(
+            expected_file, storage=storage_context
+        )
         assert isinstance(context_loaded_file, Model)
 
     def test_can_list_estimators(self, classifier: Model, tmp_path: pathlib.Path):


### PR DESCRIPTION
Updated `Model.load_estimator` to use default storage if no storage is passed

- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md
