### PR TITLE
Unpinning sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NAME = "ml_tooling"
 PACKAGES = find_packages(where="src")
 INSTALL_REQUIRES = [
     "pandas",
-    "scikit-learn>=0.22.1,<=0.23.1",
+    "scikit-learn",
     "matplotlib",
     "pyyaml",
     "joblib",


### PR DESCRIPTION
scikit-optimize has released a fix for their compatiblity issue with sklearn >= 23.1

Should be safe to unpin now
