### PR TITLE
add metrics and cv to refitting in Model.test_estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v.0.12.1
 - Dataset features can now be easily accessed with the property dataset.features
+- `model.test_estimators` with CV will keep using CV if it's refitting the best estimator.
 
 # v0.12.0
 - Permutation importance and Feature importance are now two different plotting methods.

--- a/src/ml_tooling/baseclass.py
+++ b/src/ml_tooling/baseclass.py
@@ -370,7 +370,7 @@ class Model:
             f"{results[0].metrics.name}: {results[0].metrics.score}"
         )
         if refit:
-            best_estimator.score_estimator(data)
+            best_estimator.score_estimator(data, metrics=metrics, cv=cv)
 
         return best_estimator, results
 

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -601,6 +601,24 @@ class TestModelSelection:
         )
         assert all(metric in best_estimator.result.metrics for metric in metrics)
 
+    def test_model_selection_uses_cv_parameter_in_refitting(self, train_iris_dataset):
+        estimators = [
+            LogisticRegression(solver="liblinear"),
+            RandomForestClassifier(n_estimators=10),
+        ]
+
+        metrics = ["roc_auc", "f1_macro"]
+        cv = 2
+
+        best_estimator, results = Model.test_estimators(
+            train_iris_dataset, estimators, metrics=metrics, refit=True
+        )
+        best_estimator_cv, results = Model.test_estimators(
+            train_iris_dataset, estimators, metrics=metrics, refit=True, cv=cv
+        )
+        assert not best_estimator.result.metrics[0].cross_val_scores
+        assert len(best_estimator_cv.result.metrics[0].cross_val_scores) == cv
+
     def test_model_selection_with_pipeline_works_as_expected(
         self,
         pipeline_logistic: Pipeline,

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -587,7 +587,7 @@ class TestModelSelection:
         for result in results:
             assert "roc_auc" in result.metrics
 
-    def test_model_selection_with_nonstandard_metric_and_refitting_works_as_expected(
+    def test_model_selection_with_nonstandard_metric_and_refitting_keeps_same_metric(
         self, train_iris_dataset
     ):
         estimators = [

--- a/tests/test_baseclass.py
+++ b/tests/test_baseclass.py
@@ -587,6 +587,20 @@ class TestModelSelection:
         for result in results:
             assert "roc_auc" in result.metrics
 
+    def test_model_selection_with_nonstandard_metric_and_refitting_works_as_expected(
+        self, train_iris_dataset
+    ):
+        estimators = [
+            LogisticRegression(solver="liblinear"),
+            RandomForestClassifier(n_estimators=10),
+        ]
+
+        metrics = ["roc_auc", "f1_macro"]
+        best_estimator, results = Model.test_estimators(
+            train_iris_dataset, estimators, metrics=metrics, refit=True
+        )
+        assert all(metric in best_estimator.result.metrics for metric in metrics)
+
     def test_model_selection_with_pipeline_works_as_expected(
         self,
         pipeline_logistic: Pipeline,


### PR DESCRIPTION
- [X] closes #751 
- [ ] Tests added
I've added a test for the metrics but I don't really know how to test if the cv is used in refitting.
- [X] Passes flake8
- [ ] Updated CHANGELOG
- [ ] Updated README.md
