### PR TITLE
Adding parameters to Result class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v.0.12.1
 - Dataset features can now be easily accessed with the property dataset.features
 - `model.test_estimators` with CV will keep using CV if it's refitting the best estimator.
+- `Result` now has a `.parameters` attribute to show what parameters generated the result
 
 # v0.12.0
 - Permutation importance and Feature importance are now two different plotting methods.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -72,6 +72,15 @@ We can see that the results are sorted and shows us a nice repr of each model's 
     >>> results
     ResultGroup(results=[<Result RandomForestClassifier: {'accuracy': 0.95, 'roc_auc': 0.98}>, <Result LogisticRegression: {'accuracy': 0.71, 'roc_auc': 0.79}>, <Result DummyClassifier: {'accuracy': 0.55, 'roc_auc': 0.52}>])
 
+
+You can access the parameters via the :attr:`Result.parameters <ml_tooling.result.result.Result.parameters>` attribute.
+
+.. doctest::
+
+    >>> results.parameters
+    {'bootstrap': True, 'ccp_alpha': 0.0, 'class_weight': None, 'criterion': 'gini', 'max_depth': None, 'max_features': 'auto', 'max_leaf_nodes': None, 'max_samples': None, 'min_impurity_decrease': 0.0, 'min_impurity_split': None, 'min_samples_leaf': 1, 'min_samples_split': 2, 'min_weight_fraction_leaf': 0.0, 'n_estimators': 10, 'n_jobs': None, 'oob_score': False, 'random_state': 42, 'verbose': 0, 'warm_start': False}
+
+
 From our results, the :class:`~sklearn.ensemble.RandomForestClassifier` looks the most promising, so we want to see if
 we can tune it a bit more. We can run a gridsearch over the hyperparameters using the :meth:`~Model.gridsearch` method.
 We also want to log the results, so we can examine each potential model in depth, so we use the :meth:`~Model.log`

--- a/src/ml_tooling/result/result.py
+++ b/src/ml_tooling/result/result.py
@@ -47,6 +47,10 @@ class Result:
         model.result = self
         return model
 
+    @property
+    def parameters(self):
+        return self.estimator.get_params()
+
     @classmethod
     def from_estimator(
         cls,

--- a/src/ml_tooling/result/result.py
+++ b/src/ml_tooling/result/result.py
@@ -41,6 +41,7 @@ class Result:
 
     @property
     def model(self):
+        """Return the model used in the result"""
         from ml_tooling import Model
 
         model = Model(self.estimator)
@@ -49,6 +50,7 @@ class Result:
 
     @property
     def parameters(self):
+        """Return the estimator params"""
         return self.estimator.get_params()
 
     @classmethod
@@ -61,6 +63,30 @@ class Result:
         n_jobs: int = None,
         verbose: int = 0,
     ) -> "Result":
+        """
+        Create a result from an estimator
+
+        Parameters
+        ----------
+        estimator : Estimator
+            The trained estimator
+        data : Dataset
+            The dataset used to create the result
+        metrics : List[str]
+            What metrics to calculate
+        cv : Any
+            If CV is an int, run with that many CV iterations. If a sklearn-compatible CV object
+            is passed, use that object to generate the CV splits
+        n_jobs : int
+            How many jobs to parallelize with
+        verbose : int
+            How verbose should the parallelization be
+
+        Returns
+        -------
+        Result
+            An instance of Result
+        """
         metrics = Metrics.from_list(metrics)
         if cv:
             metrics.score_metrics_cv(
@@ -77,6 +103,21 @@ class Result:
         return cls(metrics=metrics, estimator=estimator, data=data)
 
     def log(self, saved_estimator_path=None, savedir=None) -> Log:
+        """
+        Generate a Log object from the result
+
+        Parameters
+        ----------
+        saved_estimator_path : Union[str, pathlib.Path, None]
+            Optionally, where the saved estimator is
+        savedir : Union[str, pathlib.Path, None]
+            An optional path of where to save the log
+
+        Returns
+        -------
+        Log
+            An instance of Log
+        """
         log = Log.from_result(result=self, estimator_path=saved_estimator_path)
         if savedir:
             log.save_log(savedir)

--- a/tests/test_results/test_result.py
+++ b/tests/test_results/test_result.py
@@ -110,3 +110,9 @@ class TestResult:
         log = Log.from_result(result)
         log2 = result.log()
         assert log == log2
+
+    def test_result_can_show_model_parameters(self, result: Result):
+        """Expect a log to be able to show what parameters were used to generate it"""
+        parameters = result.parameters
+        expected = result.estimator.get_params()
+        assert parameters == expected


### PR DESCRIPTION
Adds a `parameters` property to the Results class for easy access to what parameters were used to get this result

- [x] closes #610 
- [x] Tests added
- [x] Passes flake8
- [x] Updated CHANGELOG
- [x] Updated README.md
